### PR TITLE
Dispatch CHANGES_REQUESTED review comments to Discord (\#187)

### DIFF
--- a/archived_test.go
+++ b/archived_test.go
@@ -8,44 +8,44 @@ import (
 // TestParseArchivedRepos tests parsing of gh repo list JSON output.
 func TestParseArchivedRepos(t *testing.T) {
 	tests := []struct {
-		name          string
-		jsonInput     string
-		wantArchived  map[string]bool
-		wantErr       bool
+		name         string
+		jsonInput    string
+		wantArchived map[string]bool
+		wantErr      bool
 	}{
 		{
-			name:        "archived and non-archived",
-			jsonInput:   `[{"name":"f","nameWithOwner":"m/f","isArchived":false},{"name":"o","nameWithOwner":"m/o","isArchived":true}]`,
+			name:         "archived and non-archived",
+			jsonInput:    `[{"name":"f","nameWithOwner":"m/f","isArchived":false},{"name":"o","nameWithOwner":"m/o","isArchived":true}]`,
 			wantArchived: map[string]bool{"m/o": true}, wantErr: false,
 		},
 		{
-			name:        "empty list",
-			jsonInput:   `[]`,
+			name:         "empty list",
+			jsonInput:    `[]`,
 			wantArchived: map[string]bool{}, wantErr: false,
 		},
 		{
-			name:        "malformed JSON",
-			jsonInput:   `[{"name": "test", "isArchived":}]`,
+			name:         "malformed JSON",
+			jsonInput:    `[{"name": "test", "isArchived":}]`,
 			wantArchived: nil, wantErr: true,
 		},
 		{
-			name:        "invalid JSON",
-			jsonInput:   `not json`,
+			name:         "invalid JSON",
+			jsonInput:    `not json`,
 			wantArchived: nil, wantErr: true,
 		},
 		{
-			name:        "all archived",
-			jsonInput:   `[{"name":"l","nameWithOwner":"m/l","isArchived":true}]`,
+			name:         "all archived",
+			jsonInput:    `[{"name":"l","nameWithOwner":"m/l","isArchived":true}]`,
 			wantArchived: map[string]bool{"m/l": true}, wantErr: false,
 		},
 		{
-			name:        "multiple archived repos",
-			jsonInput:   `[{"name":"a","nameWithOwner":"org/a","isArchived":true},{"name":"b","nameWithOwner":"org/b","isArchived":true},{"name":"c","nameWithOwner":"org/c","isArchived":false}]`,
+			name:         "multiple archived repos",
+			jsonInput:    `[{"name":"a","nameWithOwner":"org/a","isArchived":true},{"name":"b","nameWithOwner":"org/b","isArchived":true},{"name":"c","nameWithOwner":"org/c","isArchived":false}]`,
 			wantArchived: map[string]bool{"org/a": true, "org/b": true}, wantErr: false,
 		},
 		{
-			name:        "repo with special characters",
-			jsonInput:   `[{"name":"my-repo","nameWithOwner":"org/my-repo","isArchived":true}]`,
+			name:         "repo with special characters",
+			jsonInput:    `[{"name":"my-repo","nameWithOwner":"org/my-repo","isArchived":true}]`,
 			wantArchived: map[string]bool{"org/my-repo": true}, wantErr: false,
 		},
 	}

--- a/errors.go
+++ b/errors.go
@@ -54,7 +54,7 @@ func classifyError(err error) ErrorKind {
 		"ref not found",
 		"no such file or directory", // gh CLI not installed
 		"command not found",
-		"could not read username",   // auth issues
+		"could not read username", // auth issues
 		"bad credentials",
 		"invalid credentials",
 		"resource not found",

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSummarize_review_dispatched(t *testing.T) {
+	results := []prOutcome{
+		{Action: "review_dispatched"},
+	}
+	merged, commented, skipped, errs := summarize(results)
+	if merged != 0 {
+		t.Errorf("expected merged=0, got %d", merged)
+	}
+	if commented != 1 {
+		t.Errorf("expected commented=1, got %d", commented)
+	}
+	if skipped != 0 {
+		t.Errorf("expected skipped=0, got %d", skipped)
+	}
+	if errs != 0 {
+		t.Errorf("expected errs=0, got %d", errs)
+	}
+}


### PR DESCRIPTION
Implement GitHub issue \#187:

- Fetch specific review comments for PRs blocked on `reviewDecision == "CHANGES_REQUESTED"`
- Post formatted alert to `discordAlertsTo` channel for automation
- New action type `review_dispatched`, captured ReviewComments
- Tests + verified build/vet/test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically capture and dispatch review comments when pull requests require changes
  * Include detailed reviewer feedback directly in Discord notifications for enhanced transparency
  * Improved visibility into PR revision requirements

* **Tests**
  * Added test coverage for new review dispatch functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->