### PR TITLE
fix: GraphQL merge mutation parse error

### DIFF
--- a/main.go
+++ b/main.go
@@ -761,7 +761,15 @@ func ghMergePR(pullRequestNodeID string) (string, error) {
 	if strings.TrimSpace(pullRequestNodeID) == "" {
 		return "", errors.New("pull request node id required")
 	}
-	query := `mutation($pullRequestId: ID!) {\n  mergePullRequest(input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }) {\n    pullRequest {\n      merged\n      mergedAt\n      mergeCommit { oid }\n    }\n  }\n}`
+	query := `mutation($pullRequestId: ID!) {
+  mergePullRequest(input: { pullRequestId: $pullRequestId, mergeMethod: MERGE }) {
+    pullRequest {
+      merged
+      mergedAt
+      mergeCommit { oid }
+    }
+  }
+}`
 	args := []string{
 		"api", "graphql",
 		"-f", "query=" + query,


### PR DESCRIPTION
The GraphQL merge mutation query used literal `\n` in a Go backtick (raw) string. In raw strings, `\n` is two characters (backslash + n), not a newline. GitHub's GraphQL parser rejected the backslash as `UNKNOWN_CHAR` at position 32.

Fix: use actual newlines in the backtick string.

Fixes merge failure reported in #factory-alerts for fab-backlog/pull/4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code formatting improvements with no functional changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->